### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -2,6 +2,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import express, { type NextFunction, type Request, type Response } from "express";
 import helmet from "helmet";
+import rateLimit from "express-rate-limit";
 import { ZodError } from "zod";
 import { config } from "./config";
 import { AppError } from "./lib/errors";
@@ -23,6 +24,13 @@ import { trackedProductsRouter } from "./routes/tracked-products";
 
 export const createApp = () => {
     const app = express();
+
+    const globalLimiter = rateLimit({
+        windowMs: 60 * 1000, // 1 minute
+        max: 300, // allow up to 300 requests per minute per IP
+        standardHeaders: true,
+        legacyHeaders: false,
+    });
 
     if (trustedOriginsMetadata.hasLegacyMismatch) {
         logger.warn("frontend_origin_legacy_mismatch", {
@@ -50,6 +58,7 @@ export const createApp = () => {
     app.use(cookieParser());
     app.use(express.json());
     app.use(requestContextMiddleware);
+    app.use(globalLimiter);
     app.use(hydrateAuthOptional);
     app.use("/api", apiReadLimiter);
     app.use("/api", apiAuthenticatedIpCeilingLimiter);


### PR DESCRIPTION
Potential fix for [https://github.com/fredkorts/scraper/security/code-scanning/2](https://github.com/fredkorts/scraper/security/code-scanning/2)

In general, the fix is to ensure that any middleware performing authorization or other potentially expensive operations is protected by rate limiting. For this app, the simplest and least invasive way is to add a global, relatively generous rate limiter early in the middleware chain, *before* `hydrateAuthOptional`. That way, abusive request floods will be throttled before they can trigger heavy auth logic, while regular usage should not be affected.

Concretely, we can use the widely adopted `express-rate-limit` package. In `backend/src/app.ts`, we will:

1. Add an import for `express-rate-limit`.
2. Define a global limiter instance with appropriate settings (e.g., a high but finite number of requests per minute per IP).
3. Apply this limiter with `app.use(globalLimiter);` just before `app.use(hydrateAuthOptional);`.

We will not alter existing `/api`-scoped limiters or route registrations. We’ll also keep the limiter configuration self-contained in this file, using conservative defaults so existing functionality and behavior are preserved aside from adding protection against extreme request volumes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
